### PR TITLE
properly create mosquitto_account during provisioning

### DIFF
--- a/app/controllers/provision_controller.rb
+++ b/app/controllers/provision_controller.rb
@@ -40,7 +40,7 @@ class ProvisionController < ApplicationController
     else
       pr = ProvisionRequest.create args
       if pr
-        ma = pr.build_mosquitto_account(superuser: true)
+        ma = pr.create_mosquitto_account(superuser: true, password: '')
         ma.generate_password!
 
         requested_devices.each do |device|

--- a/app/models/mosquitto_account.rb
+++ b/app/models/mosquitto_account.rb
@@ -4,8 +4,14 @@ class MosquittoAccount < ApplicationRecord
   def generate_password!
     unencoded_password = _get_random_string(32)
 
-    hashed_password = `np -i 1000 -p #{unencoded_password}`
-    hashed_password.chomp!
+    hashed_password = ''
+
+    if Rails.env.development?
+      hashed_password = 'this is really not gonna work'
+    else
+      hashed_password = `np -i 1000 -p #{unencoded_password}`
+      hashed_password.chomp!
+    end
 
     puts "unencoded password for device is #{unencoded_password}"
     puts "encoded password for device is #{hashed_password}"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_25_190806) do
+ActiveRecord::Schema.define(version: 2018_05_28_202619) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -40,7 +40,6 @@ ActiveRecord::Schema.define(version: 2018_05_25_190806) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["provision_request_id"], name: "index_mosquitto_accounts_on_provision_request_id"
-    t.index ["username"], name: "index_mosquitto_accounts_on_username"
   end
 
   create_table "mosquitto_acls", force: :cascade do |t|


### PR DESCRIPTION
make MQTT account passwords not error out on development environments (still won't work)